### PR TITLE
Admin should be able to soft delete a member

### DIFF
--- a/app/models/member.py
+++ b/app/models/member.py
@@ -62,3 +62,11 @@ class Member(db.Model):
             db.session.commit()
             return True
         return False
+    
+    def soft_delete(self):
+        """Soft delete the member by setting is_active to False"""
+        if not self.is_active:
+            return {'error': 'Member is already inactive.'}, 400
+        self.is_active = False
+        db.session.commit()
+        return {'message': f'Member {self.id} has been soft deleted successfully'}, 200


### PR DESCRIPTION
**Overview**
This pull request implements the functionality that allows administrators to soft delete members from the system. Soft deletion is a method of marking a record as deleted without physically removing it from the database. This approach ensures that member data can be retained for auditing or recovery purposes while preventing it from being accessible in active queries.

**Key Changes**:
Added an is_active column to the Member model to indicate whether a member is active or soft-deleted.
Introduced the soft_delete_member method in the MemberService class to handle the logic for soft deletion.
This method sets the is_active attribute to False for the specified member ID and commits the changes to the database.
Modified the MemberController to include a new route for the soft delete operation. This route accepts a DELETE request and returns an appropriate response indicating the success or failure of the operation.
**Screenshots**
![Screenshot from 2024-10-13 21-29-16](https://github.com/user-attachments/assets/4ff1bd5c-e62c-4959-94af-a245c3e0c9b2)
